### PR TITLE
Kill child processes when cancelling download. Fixes #1

### DIFF
--- a/src/NYoutubeDL/NYoutubeDLP.csproj
+++ b/src/NYoutubeDL/NYoutubeDLP.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.12.2</Version>
+    <Version>0.13.0</Version>
     <Authors>Brian Allred, Anthony Atanasov</Authors>
     <Company />
     <Product />
@@ -12,8 +12,8 @@
     <PackageProjectUrl>https://github.com/Antfere/NYoutubeDLP</PackageProjectUrl>
     <PackageTags>youtube-dl youtube-dlp yt-dlp</PackageTags>
     <NeutralLanguage></NeutralLanguage>
-    <AssemblyVersion>0.12.2.0</AssemblyVersion>
-    <FileVersion>0.12.2.0</FileVersion>
+    <AssemblyVersion>0.13.0.0</AssemblyVersion>
+    <FileVersion>0.13.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/NYoutubeDL/NYoutubeDLP.csproj
+++ b/src/NYoutubeDL/NYoutubeDLP.csproj
@@ -16,6 +16,6 @@
     <FileVersion>0.13.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/src/NYoutubeDL/Services/DownloadService.cs
+++ b/src/NYoutubeDL/Services/DownloadService.cs
@@ -53,11 +53,6 @@ namespace NYoutubeDL.Services
                 Cancel(ydl);
             });
 
-            if (!ydl.isGettingInfo)
-            {
-                ydl.IsDownloading = true;
-            }
-
             if (ydl.processStartInfo == null)
             {
                 ydl.isGettingInfo = true;
@@ -97,11 +92,6 @@ namespace NYoutubeDL.Services
             {
                 Cancel(ydl);
             });
-
-            if (!ydl.isGettingInfo)
-            {
-                ydl.IsDownloading = true;
-            }
 
             if (ydl.processStartInfo == null)
             {
@@ -191,6 +181,7 @@ namespace NYoutubeDL.Services
             }
 
             ydl.process.Start();
+            ydl.IsDownloading = true;
             ydl.downloadProcessID = ydl.process.Id;
         }
 

--- a/src/NYoutubeDL/YoutubeDLP.cs
+++ b/src/NYoutubeDL/YoutubeDLP.cs
@@ -337,7 +337,7 @@ namespace NYoutubeDL
                 {
                     if (!this.process.HasExited)
                     {
-                        this.process.Kill();
+                        this.process.Kill(true);
                     }
 
                     this.process.Dispose();


### PR DESCRIPTION
Now uses the [`Process.Kill()` overload that takes a boolean to kill child processes](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-6.0#system-diagnostics-process-kill(system-boolean)), which will fix #1.

This required updating the Target Framework to .NET Core 3.1 (`netcoreapp3.1`), and I updated Newtonsoft.Json at the same time. I also bumped the package version to 0.13.0, rather than 0.12.3, since changing the target framework breaks compatibility with .NET Framework. 

Theoretically it could (and probably should) be updated to .NET 6, as that's the latest LTS release, with 3.1 being EOL in December. I did briefly set it to use .NET 6 and it seemed the only real issue was the fact that the other projects in the solution are on 3.1, and can't reference the higher version. Should just be a matter of setting those projects to also use .NET 6, but I decided to leave that for a later date. 

I also moved the setting of `ydl.IsDownloading` to be slightly more accurate (at the end of `SetupDownload()`), since when I was writing tests I found that there's a bit of a delay before the process actually gets spawned. 

I've tested it with the application I'm developing where I first encountered this issue, and it seems to work fine now. 
As mentioned, I also wrote some test coverage to ensure that processes are being killed fully. You may note that there's some 'hacky' things in there to wait for the download, but I wasn't able to come up with a cleaner solution unfortunately. 